### PR TITLE
feat: add mcp() hook with vscode-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Visual Studio Code: extensions, profiles, sandbox management,
+and MCP server (`vscode-mcp-server` via npm) for AI-driven editor integration.
 
 ## Contributing
 
@@ -40,6 +41,7 @@ TODO: Add a short summary of this module.
 - `ppcde` -> `p6df::modules::vscode::sandbox::select perl;   p6df::modules::vscode::sandbox::runner`
 - `pycde` -> `p6df::modules::vscode::sandbox::select python; p6df::modules::vscode::sandbox::runner`
 - `rucde` -> `p6df::modules::vscode::sandbox::select rust;   p6df::modules::vscode::sandbox::runner`
+- `srcde` -> `p6df::modules::vscode::sandbox::select sre;    p6df::modules::vscode::sandbox::runner`
 
 ### Functions
 
@@ -54,6 +56,7 @@ TODO: Add a short summary of this module.
     - _module
     - dir
 - `p6df::modules::vscode::langs()`
+- `p6df::modules::vscode::mcp()`
 - `p6df::modules::vscode::profile::off()`
 - `p6df::modules::vscode::profile::on(profile)`
   - Args:

--- a/init.zsh
+++ b/init.zsh
@@ -250,3 +250,17 @@ p6df::modules::vscode::profile::off() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::vscode::mcp()
+#
+#>
+######################################################################
+p6df::modules::vscode::mcp() {
+
+  p6_js_npm_global_install "vscode-mcp-server"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::vscode::mcp()` installing `vscode-mcp-server` via npm
- Regenerated README with updated function list and Summary

## Test plan
- [ ] `p6df::modules::vscode::mcp()` installs `vscode-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)