### PR TITLE
fix: remove stale TODO for gemini/copilot/claudecode extensions

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -170,8 +170,6 @@ p6df::modules::vscode::aliases::init() {
 ######################################################################
 p6df::modules::vscode::langs() {
 
-  # TODO: gemini, copilot, claudecode
-
   p6df::modules::vscode::sandbox::create cdk      "Kimbie Dark"         vscode shell git github aws eslint js playwright
   p6df::modules::vscode::sandbox::create go       "Tomorrow Night Blue" vscode shell git github go
   p6df::modules::vscode::sandbox::create java     "Monokai Dimmed"      vscode shell git github java


### PR DESCRIPTION
## Summary
- Remove `# TODO: gemini, copilot, claudecode` comment; each module now manages its own extensions

## Test plan
- [ ] Verify no regression in extension installation