### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::vscode::deps()
-#
-#>
-######################################################################
 p6df::modules::vscode::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-shell
@@ -13,11 +7,63 @@ p6df::modules::vscode::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::vscode::vscodes()
-#
-#>
+p6df::modules::vscode::aliases::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  p6_alias "p6_code" "p6df::modules::vscode::sandbox::runner"
+  p6_alias "cde" "p6_code"
+  p6_alias "cdel" "p6df::modules::vscode::extensions::list"
+  p6_alias "cdeL" "p6df::modules::vscode::extension::install"
+
+  p6_alias "acde"  "p6df::modules::vscode::sandbox::select all;    p6df::modules::vscode::sandbox::runner"
+  p6_alias "ccde"  "p6df::modules::vscode::sandbox::select cdk;    p6df::modules::vscode::sandbox::runner"
+  p6_alias "srcde" "p6df::modules::vscode::sandbox::select sre;    p6df::modules::vscode::sandbox::runner"
+  p6_alias "gcde"  "p6df::modules::vscode::sandbox::select go;     p6df::modules::vscode::sandbox::runner"
+  p6_alias "jcde"  "p6df::modules::vscode::sandbox::select java;   p6df::modules::vscode::sandbox::runner"
+  p6_alias "ncde"  "p6df::modules::vscode::sandbox::select nextjs; p6df::modules::vscode::sandbox::runner"
+  p6_alias "ppcde" "p6df::modules::vscode::sandbox::select perl;   p6df::modules::vscode::sandbox::runner"
+  p6_alias "pycde" "p6df::modules::vscode::sandbox::select python; p6df::modules::vscode::sandbox::runner"
+  p6_alias "rcde"  "p6df::modules::vscode::sandbox::select rails;  p6df::modules::vscode::sandbox::runner"
+  p6_alias "rucde" "p6df::modules::vscode::sandbox::select rust;   p6df::modules::vscode::sandbox::runner"
+  p6_alias "scde"  "p6df::modules::vscode::sandbox::select shell;  p6df::modules::vscode::sandbox::runner"
+
+  p6_alias "code" "p6_code"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::vscode::langs() {
+
+  p6df::modules::vscode::sandbox::create cdk      "Kimbie Dark"         vscode shell git github aws eslint js playwright
+  p6df::modules::vscode::sandbox::create go       "Tomorrow Night Blue" vscode shell git github go
+  p6df::modules::vscode::sandbox::create java     "Monokai Dimmed"      vscode shell git github java
+  p6df::modules::vscode::sandbox::create nextjs   "Abyss"               vscode shell git github eslint js playwright
+  p6df::modules::vscode::sandbox::create perl     "Experimental Dark"   vscode shell git github perl
+  p6df::modules::vscode::sandbox::create python   "Default Light+"      vscode shell git github python
+  p6df::modules::vscode::sandbox::create rails    "Solarized Dark"      vscode shell git github ruby rails
+  p6df::modules::vscode::sandbox::create rust     "Red"                 vscode shell git github rust
+  p6df::modules::vscode::sandbox::create shell    "Default Dark+"       vscode shell git github
+  p6df::modules::vscode::sandbox::create sre      "Solarized Light"     vscode shell git github docker jenkins launchdarkly kubernetes terraform
+
+  p6df::modules::vscode::sandbox::create all      "Visual Studio Light" aws c cucumber docker eslint git github go java js jupyter perl playwright python ruby rust shell snowflake terraform vscode
+
+  p6_env_export_un "P6_DFZ_VSCODE_SANDBOX_NAME"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::vscode::mcp() {
+
+  p6_js_npm_global_install "vscode-mcp-server"
+
+  p6df::modules::anthropic::mcp::server::add "vscode" "npx" "-y" "vscode-mcp-server"
+  p6df::modules::openai::mcp::server::add "vscode" "npx" "-y" "vscode-mcp-server"
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::vscode::vscodes() {
 
@@ -58,12 +104,6 @@ p6df::modules::vscode::vscodes() {
 
   p6_return_void
 }
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::vscodes::config()
-#
-#>
 ######################################################################
 p6df::modules::vscode::vscodes::config() {
 
@@ -110,38 +150,53 @@ EOF
 }
 
 ######################################################################
+p6df::modules::vscode::profile::on() {
+  local profile="$1"
+  local code="$2"
+
+  p6_run_code "$code"
+
+  p6_env_export "P6_DFZ_VSCODE_PROFILE"     "$profile"
+  p6_env_export "P6_DFZ_VSCODE_SANDBOX_DIR" "$HOME/.vscode-sandboxes"
+
+  p6_return_void
+}
+
+# shellcheck disable=2329
+######################################################################
+p6df::modules::vscode::profile::off() {
+
+  p6_env_export_un P6_DFZ_VSCODE_PROFILE
+  p6_env_export_un P6_DFZ_VSCODE_SANDBOX_DIR
+  p6_env_export_un P6_DFZ_VSCODE_SANDBOX_NAME
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::vscode::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::vscode::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::vscode::vscodes::config()
+#
+#>
+######################################################################
 #<
 #
 # Function: p6df::modules::vscode::aliases::init()
 #
 #>
-######################################################################
-p6df::modules::vscode::aliases::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  p6_alias "p6_code" "p6df::modules::vscode::sandbox::runner"
-  p6_alias "cde" "p6_code"
-  p6_alias "cdel" "p6df::modules::vscode::extensions::list"
-  p6_alias "cdeL" "p6df::modules::vscode::extension::install"
-
-  p6_alias "acde"  "p6df::modules::vscode::sandbox::select all;    p6df::modules::vscode::sandbox::runner"
-  p6_alias "ccde"  "p6df::modules::vscode::sandbox::select cdk;    p6df::modules::vscode::sandbox::runner"
-  p6_alias "srcde" "p6df::modules::vscode::sandbox::select sre;    p6df::modules::vscode::sandbox::runner"
-  p6_alias "gcde"  "p6df::modules::vscode::sandbox::select go;     p6df::modules::vscode::sandbox::runner"
-  p6_alias "jcde"  "p6df::modules::vscode::sandbox::select java;   p6df::modules::vscode::sandbox::runner"
-  p6_alias "ncde"  "p6df::modules::vscode::sandbox::select nextjs; p6df::modules::vscode::sandbox::runner"
-  p6_alias "ppcde" "p6df::modules::vscode::sandbox::select perl;   p6df::modules::vscode::sandbox::runner"
-  p6_alias "pycde" "p6df::modules::vscode::sandbox::select python; p6df::modules::vscode::sandbox::runner"
-  p6_alias "rcde"  "p6df::modules::vscode::sandbox::select rails;  p6df::modules::vscode::sandbox::runner"
-  p6_alias "rucde" "p6df::modules::vscode::sandbox::select rust;   p6df::modules::vscode::sandbox::runner"
-  p6_alias "scde"  "p6df::modules::vscode::sandbox::select shell;  p6df::modules::vscode::sandbox::runner"
-
-  p6_alias "code" "p6_code"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -149,27 +204,6 @@ p6df::modules::vscode::aliases::init() {
 #
 #  Environment:	 P6_DFZ_VSCODE_SANDBOX_NAME
 #>
-######################################################################
-p6df::modules::vscode::langs() {
-
-  p6df::modules::vscode::sandbox::create cdk      "Kimbie Dark"         vscode shell git github aws eslint js playwright
-  p6df::modules::vscode::sandbox::create go       "Tomorrow Night Blue" vscode shell git github go
-  p6df::modules::vscode::sandbox::create java     "Monokai Dimmed"      vscode shell git github java
-  p6df::modules::vscode::sandbox::create nextjs   "Abyss"               vscode shell git github eslint js playwright
-  p6df::modules::vscode::sandbox::create perl     "Experimental Dark"   vscode shell git github perl
-  p6df::modules::vscode::sandbox::create python   "Default Light+"      vscode shell git github python
-  p6df::modules::vscode::sandbox::create rails    "Solarized Dark"      vscode shell git github ruby rails
-  p6df::modules::vscode::sandbox::create rust     "Red"                 vscode shell git github rust
-  p6df::modules::vscode::sandbox::create shell    "Default Dark+"       vscode shell git github
-  p6df::modules::vscode::sandbox::create sre      "Solarized Light"     vscode shell git github docker jenkins launchdarkly kubernetes terraform
-
-  p6df::modules::vscode::sandbox::create all      "Visual Studio Light" aws c cucumber docker eslint git github go java js jupyter perl playwright python ruby rust shell snowflake terraform vscode
-
-  p6_env_export_un "P6_DFZ_VSCODE_SANDBOX_NAME"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -205,20 +239,6 @@ p6df::modules::vscode::prompt::system() {
 #  Environment:	 HOME P6_DFZ_VSCODE_PROFILE P6_DFZ_VSCODE_SANDBOX_DIR
 #>
 ######################################################################
-p6df::modules::vscode::profile::on() {
-  local profile="$1"
-  local code="$2"
-
-  p6_run_code "$code"
-
-  p6_env_export "P6_DFZ_VSCODE_PROFILE"     "$profile"
-  p6_env_export "P6_DFZ_VSCODE_SANDBOX_DIR" "$HOME/.vscode-sandboxes"
-
-  p6_return_void
-}
-
-# shellcheck disable=2329
-######################################################################
 #<
 #
 # Function: p6df::modules::vscode::profile::off()
@@ -226,28 +246,8 @@ p6df::modules::vscode::profile::on() {
 #  Environment:	 P6_DFZ_VSCODE_PROFILE P6_DFZ_VSCODE_SANDBOX_DIR P6_DFZ_VSCODE_SANDBOX_NAME
 #>
 ######################################################################
-p6df::modules::vscode::profile::off() {
-
-  p6_env_export_un P6_DFZ_VSCODE_PROFILE
-  p6_env_export_un P6_DFZ_VSCODE_SANDBOX_DIR
-  p6_env_export_un P6_DFZ_VSCODE_SANDBOX_NAME
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::vscode::mcp()
 #
 #>
-######################################################################
-p6df::modules::vscode::mcp() {
-
-  p6_js_npm_global_install "vscode-mcp-server"
-
-  p6df::modules::anthropic::mcp::server::add "vscode" "npx" "-y" "vscode-mcp-server"
-  p6df::modules::openai::mcp::server::add "vscode" "npx" "-y" "vscode-mcp-server"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,23 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::vscode::deps()
+#
+#>
+######################################################################
 p6df::modules::vscode::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-shell
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::vscode::aliases::init()
+#
+#>
 ######################################################################
 p6df::modules::vscode::aliases::init() {
 
@@ -34,6 +46,13 @@ p6df::modules::vscode::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::vscode::langs()
+#
+#  Environment:	 P6_DFZ_VSCODE_SANDBOX_NAME
+#>
+######################################################################
 p6df::modules::vscode::langs() {
 
   p6df::modules::vscode::sandbox::create cdk      "Kimbie Dark"         vscode shell git github aws eslint js playwright
@@ -55,6 +74,12 @@ p6df::modules::vscode::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::vscode::mcp()
+#
+#>
+######################################################################
 p6df::modules::vscode::mcp() {
 
   p6_js_npm_global_install "vscode-mcp-server"
@@ -64,6 +89,12 @@ p6df::modules::vscode::mcp() {
 
   p6_return_void
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::vscode::vscodes()
+#
+#>
 ######################################################################
 p6df::modules::vscode::vscodes() {
 
@@ -104,6 +135,12 @@ p6df::modules::vscode::vscodes() {
 
   p6_return_void
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::vscode::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::vscode::vscodes::config() {
 
@@ -150,6 +187,17 @@ EOF
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::vscode::profile::on(profile, code)
+#
+#  Args:
+#	profile -
+#	code -
+#
+#  Environment:	 HOME P6_DFZ_VSCODE_PROFILE P6_DFZ_VSCODE_SANDBOX_DIR
+#>
+######################################################################
 p6df::modules::vscode::profile::on() {
   local profile="$1"
   local code="$2"
@@ -164,6 +212,13 @@ p6df::modules::vscode::profile::on() {
 
 # shellcheck disable=2329
 ######################################################################
+#<
+#
+# Function: p6df::modules::vscode::profile::off()
+#
+#  Environment:	 P6_DFZ_VSCODE_PROFILE P6_DFZ_VSCODE_SANDBOX_DIR P6_DFZ_VSCODE_SANDBOX_NAME
+#>
+######################################################################
 p6df::modules::vscode::profile::off() {
 
   p6_env_export_un P6_DFZ_VSCODE_PROFILE
@@ -173,37 +228,6 @@ p6df::modules::vscode::profile::off() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::aliases::init()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::langs()
-#
-#  Environment:	 P6_DFZ_VSCODE_SANDBOX_NAME
-#>
 ######################################################################
 #<
 #
@@ -227,27 +251,3 @@ p6df::modules::vscode::prompt::system() {
 
 
 # shellcheck disable=2329
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::profile::on(profile, code)
-#
-#  Args:
-#	profile -
-#	code -
-#
-#  Environment:	 HOME P6_DFZ_VSCODE_PROFILE P6_DFZ_VSCODE_SANDBOX_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::profile::off()
-#
-#  Environment:	 P6_DFZ_VSCODE_PROFILE P6_DFZ_VSCODE_SANDBOX_DIR P6_DFZ_VSCODE_SANDBOX_NAME
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::vscode::mcp()
-#
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None